### PR TITLE
Выравнивание текста

### DIFF
--- a/source/templates/bootstrap/less/style.less
+++ b/source/templates/bootstrap/less/style.less
@@ -39,7 +39,6 @@ article h1 h2 h3 {
 article {
     margin-top: 2em;
     text-indent:2px;
-    text-align:justify;
 }
 
 article ul li {


### PR DESCRIPTION
Вернул выравнивание текста по левому краю.
Так как переносов в вебе пока нет, бывает, что текст выравненный по ширине выглядит ужасно — https://twitter.com/andryusha/status/294331224221155328/photo/1

И да, разумеется, в описании коммита я перепутал право и лево, а как отредактировать не знаю :-)
