### PR TITLE
Check typos with yaspeller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "0.6"
+
+install:
+  - sudo npm install yaspeller -g
+
+script:
+  - yaspeller .
+
+notifications:
+  email: false

--- a/.yaspellerrc
+++ b/.yaspellerrc
@@ -1,0 +1,21 @@
+{
+  "excludeFiles": [
+	"README.md",
+	"b3",
+	"kippter",
+	"new",
+	"results",
+	"source",
+	"sync",
+	"node_modules",
+	"templates"
+  ],
+  "lang": "ru,en",
+  "fileExtensions": [
+    ".md"
+  ],
+  "dictionary": [
+  "багами",
+  "баги"
+  ]
+}


### PR DESCRIPTION
To avoid manual checking (https://github.com/bobuk/addmeto.cc#%D0%97%D0%B0%D1%87%D0%B5%D0%BC) and reduce amount of typos and mispells it is useful to check posts with yaspeller (https://github.com/hcodes/yaspeller) and exec it per commit using Travis-CI.
